### PR TITLE
Prefer external storage

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="pics.sift.app">
+    package="pics.sift.app" android:installLocation="preferExternal">
 
     <uses-sdk android:minSdkVersion="15" android:targetSdkVersion="21" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />


### PR DESCRIPTION
Currently App Install Location is set to Auto this results in that Sift.pics first will be installed to the system storage, then the user can move the app to external storage if they wish to do so. If Sift.pics instead preferred external storage the app would be installed and downloaded to the external storage if such is available. The user would still be able to move the app to the system storage after the installation.

(Short story: for most users system storage is more valued then external storage.)

Example of an user benefiting from this approach:

Currently the user has a lot of space available on his/her SD card but the system storage is almost full, this results in that the he/she can't download the app because it would first be downloaded to the system storage. If it would first be downloaded to the SD card this issue would never have happen.